### PR TITLE
Bugfix: check_snmp 2.4.8 only supports timeticks in numeric comparison

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -503,11 +503,10 @@ main (int argc, char **argv)
 		/* Process this block for numeric comparisons */
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate || is_ticks || offset != 0.0 || multiplier != 1.0) {
-			/* Find the first instance of the '(' character - the value of the OID should be contained in parens */
-			ptr = strpbrk(show, "(");
-			if (ptr == NULL)
-				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
-			ptr++; /* Move to the first character after the '(' */
+                        if ((ptr = strpbrk(show, "(")) != NULL) /* Timetick */
+                                ptr++;
+                        else if ((ptr = strpbrk(show, "-0123456789")) == NULL) /* Counter, gauge or integer */
+                                die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 			
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;


### PR DESCRIPTION
This is an attempt to rollback commit 031e5f80f36e6c88a7d42c3c75f3ef6716ffd86b.

Due to that commit, the numeric comparison in check_snmp 2.4.8 is now able to handle timeticks only, however the datatype can also be (all snmp flavours of) integer.
This patch brings check_snmp back to 2.4.6 when all kinds of numeric datatypes were supported.

good examples:
my idea is to look for an open parenthesis to be skipped, if it is missing then go straight to the first decimal digit.
iso.1... = Gauge32: 0 milliseconds
iso.1... = INTEGER: rfc2988(5)
iso.1... = Timeticks: (82289678) 9 days, 12:34:56.78

bad examples:
the user must be careful not to ask for numeric comparisons :)
iso.1... = IpAddress: 0.0.0.0
iso.1... = OID: .0.0
iso.1... = STRING: "Null0"

Cheers